### PR TITLE
Remove unused OpenCV header include

### DIFF
--- a/src/ICPOdometry.h
+++ b/src/ICPOdometry.h
@@ -10,7 +10,6 @@
 
 #include "Cuda/internal.h"
 
-#include <opencv2/opencv.hpp>
 #include <vector>
 #include <sophus/se3.hpp>
 


### PR DESCRIPTION
This should have been a part of 92357e5ec7 commit.